### PR TITLE
Solving day 7

### DIFF
--- a/docs/day7.md
+++ b/docs/day7.md
@@ -1,0 +1,39 @@
+---
+url: "https://adventofcode.com/2024/day/7"
+---
+
+# Day 7: Bridge Repair
+
+The Historians take you to a familiar rope bridge over a river in the middle of a jungle. The Chief isn't on this side of the bridge, though; maybe he's on the other side?
+
+When you go to cross the bridge, you notice a group of engineers trying to repair it. (Apparently, it breaks pretty frequently.) You won't be able to cross until it's fixed.
+
+You ask how long it'll take; the engineers tell you that it only needs final calibrations, but some young elephants were playing nearby and stole all the operators from their calibration equations! They could finish the calibrations if only someone could determine which test values could possibly be produced by placing any combination of operators into their calibration equations (your puzzle input).
+
+For example:
+
+```txt
+190: 10 19
+3267: 81 40 27
+83: 17 5
+156: 15 6
+7290: 6 8 6 15
+161011: 16 10 13
+192: 17 8 14
+21037: 9 7 18 13
+292: 11 6 16 20
+```
+
+Each line represents a single equation. The test value appears before the colon on each line; it is your job to determine whether the remaining numbers can be combined with operators to produce the test value.
+
+Operators are always evaluated left-to-right, not according to precedence rules. Furthermore, numbers in the equations cannot be rearranged. Glancing into the jungle, you can see elephants holding two different types of operators: add (`+`) and multiply (`*`).
+
+Only three of the above equations can be made true by inserting operators:
+
+* `190: 10 19` has only one position that accepts an operator: between `10` and `19`. Choosing `+` would give `29`, but choosing `*` would give the test value (`10 * 19 = 190`).
+* `3267: 81 40 27` has two positions for operators. Of the four possible configurations of the operators, two cause the right side to match the test value: `81 + 40 * 27` and `81 * 40 + 27` both equal `3267` (when evaluated left-to-right)!
+* `292: 11 6 16 20` can be solved in exactly one way: `11 + 6 * 16 + 20`.
+
+The engineers just need the total calibration result, which is the sum of the test values from just the equations that could possibly be true. In the above example, the sum of the test values for the three equations listed above is `3749`.
+
+Determine which equations could possibly be true. What is their total calibration result?

--- a/src/day7/day7.go
+++ b/src/day7/day7.go
@@ -1,0 +1,84 @@
+package day7
+
+import (
+	"slices"
+	"strconv"
+	"strings"
+)
+
+type equation struct {
+	result       uint
+	coefficients []uint
+}
+
+func Solve(input string) uint {
+	equations := parseInput(input)
+	return solve(equations)
+}
+
+func parseInput(input string) []equation {
+	result := make([]equation, 0)
+	for _, line := range strings.Split(input, "\n") {
+		var eqn equation
+		pieces := strings.Split(line, ": ")
+		if len(pieces) != 2 {
+			continue
+		}
+
+		x, err := strconv.Atoi(pieces[0])
+		if err != nil {
+			continue
+		}
+		eqn.result = uint(x)
+
+		for _, coef := range strings.Split(pieces[1], " ") {
+			y, err := strconv.Atoi(coef)
+			if err != nil {
+				continue
+			}
+			eqn.coefficients = slices.Insert(eqn.coefficients, len(eqn.coefficients), uint(y))
+		}
+
+		result = slices.Insert(result, len(result), eqn)
+	}
+	return result
+}
+
+func solve(eqns []equation) uint {
+	var result uint = 0
+	for _, eqn := range eqns {
+		if trueEquation(eqn) {
+			result += eqn.result
+		}
+	}
+	return result
+}
+
+func trueEquation(eqn equation) bool {
+	possibilities := []uint{eqn.coefficients[0]}
+	for i, coef := range eqn.coefficients {
+		if i == 0 {
+			continue
+		}
+
+		updatedPossibilities := []uint{}
+		for _, priorPartial := range possibilities {
+			sum := priorPartial + coef
+			if sum <= eqn.result {
+				updatedPossibilities = slices.Insert(updatedPossibilities, len(updatedPossibilities), sum)
+			}
+			mult := priorPartial * coef
+			if mult <= eqn.result {
+				updatedPossibilities = slices.Insert(updatedPossibilities, len(updatedPossibilities), mult)
+			}
+		}
+		possibilities = updatedPossibilities
+	}
+
+	for _, poss := range possibilities {
+		if poss == eqn.result {
+			return true
+		}
+	}
+	return false
+}

--- a/src/day7/day7_test.go
+++ b/src/day7/day7_test.go
@@ -1,0 +1,21 @@
+package day7
+
+import (
+	"testing"
+)
+
+func TestSample(t *testing.T) {
+	input := `190: 10 19
+3267: 81 40 27
+83: 17 5
+156: 15 6
+7290: 6 8 6 15
+161011: 16 10 13
+192: 17 8 14
+21037: 9 7 18 13
+292: 11 6 16 20`
+	result := Solve(input)
+	if result != 3749 {
+		t.Errorf("Calculated solution was not expected")
+	}
+}


### PR DESCRIPTION
## Summary

Solving the day 7 puzzle. This works by iterating through every given coefficient and putting into a list the previous possibilities added and multiplied the coefficient. This solution works, but the worst case time is `O(2^n)` which is terrible. If any of the possibilities are greater than the equation result, we abandon it. This is possible because each coefficient is a whole positive number, so it's impossible for the running total to decrease.